### PR TITLE
Kiksun/feature/#31

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.ignoreLimitWarning": true
+}

--- a/client/finds_client/src/App.js
+++ b/client/finds_client/src/App.js
@@ -8,6 +8,7 @@ import Home from "./components/home";
 import Error from "./components/Error";
 import DocumentDetailPage from "./components/DocumentDetailPage";
 import MyPage from "./components/myPage";
+import Result from "./components/SearchResultpage";
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
       <Switch>
         <Route exact path="/login" component={Login} />
         <Route exact path="/home" component={Home} />
+        <Route exact path="/result" component={Result}/>
         <Route path="/detail" component={DocumentDetailPage} />
         <Route exact path="/myPage" component={MyPage} />
         <Route path="/" component={Login} />

--- a/client/finds_client/src/components/SearchResultpage.js
+++ b/client/finds_client/src/components/SearchResultpage.js
@@ -35,13 +35,11 @@ const tileData = [
     cols: 2,
     featured: true,
   },
-
   {
     img: 'https://cdn.pixabay.com/photo/2014/12/27/15/31/camera-581126_1280.jpg',
     title: 'Camera',
     author: 'Image by Free-Photos on Pixabay',
   },
-
   {
     img: 'https://cdn.pixabay.com/photo/2017/05/13/12/40/fashion-2309519__480.jpg',
     title: 'Hats',

--- a/client/finds_client/src/components/SearchResultpage.js
+++ b/client/finds_client/src/components/SearchResultpage.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import GridList from '@material-ui/core/GridList';
+import GridListTile from '@material-ui/core/GridListTile';
+import GridListTileBar from '@material-ui/core/GridListTileBar';
+import ListSubheader from '@material-ui/core/ListSubheader';
+import IconButton from '@material-ui/core/IconButton';
+import InfoIcon from '@material-ui/icons/Info';
+
+
+const styles = theme => ({
+  root: {
+    width:'0%',
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'space-around',
+    overflow: 'hidden',
+    backgroundColor: theme.palette.background.paper,
+  },
+  gridList: {
+    width: '30%',
+    height: '50%',
+  },
+  icon: {
+    color: 'rgba(255, 255, 255, 0.54)',
+  },
+});
+const tileData = [
+  {
+    img: 'https://i.imagesup.co/images2/0__05c7e898ac694e.jpg',
+    title: 'fun',
+    author: 'Image by Free-Photos on Pixabay',
+    cols: 2,
+    featured: true,
+  },
+  {
+    img: 'https://i.imagesup.co/images2/0__05c7e8a33418ff.jpg',
+    title: 'dog',
+    author: 'Image by Free-Photos on Pixabay',
+  },
+  {
+    img: 'https://cdn.pixabay.com/photo/2014/12/27/15/31/camera-581126_1280.jpg',
+    title: 'Camera',
+    author: 'Image by Free-Photos on Pixabay',
+  },
+  {
+    img: 'https://cdn.pixabay.com/photo/2017/05/12/08/29/coffee-2306471_1280.jpg',
+    title: 'Morning',
+    author: 'Image by Free-Photos on Pixabay',
+    featured: true,
+  },
+  {
+    img: 'https://cdn.pixabay.com/photo/2017/05/13/12/40/fashion-2309519__480.jpg',
+    title: 'Hats',
+    author: 'Hans',
+  },
+  {
+    img: 'https://cdn.pixabay.com/photo/2015/10/26/11/10/honey-1006972__480.jpg',
+    title: 'Honey',
+    author: 'Image by Free-Photos on Pixabay',
+  }
+];
+
+
+/**
+ * The example data is structured as follows:
+ *
+ * import image from 'path/to/image.jpg';
+ * [etc...]
+ *
+ * const tileData = [
+ *   {
+ *     img: image,
+ *     title: 'Image',
+ *     author: 'author',
+ *   },
+ *   {
+ *     [etc...]
+ *   },
+ * ];
+ */
+ function SearchResultPage(props) {
+   const classes = props;
+
+  return (
+    <div className={classes.root}>
+      <GridList cellHeight={180} className={classes.gridList}>
+        <GridListTile key="Subheader" cols={4} style={{ height: 'auto' }}>
+        </GridListTile>
+        {tileData.map(tile => (
+          <GridListTile key={tile.img}>
+            <img src={tile.img} alt={tile.title} />
+            <GridListTileBar
+              title={tile.title}
+              subtitle={<span>作成者: {tile.author}</span>}
+              actionIcon={
+                <IconButton aria-label={`info about ${tile.title}`} className={classes.icon}>
+                  <InfoIcon />
+                </IconButton>
+              }
+            />
+          </GridListTile>
+        ))}
+      </GridList>
+    </div>
+  );
+}
+
+SearchResultPage.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(SearchResultPage);

--- a/client/finds_client/src/components/SearchResultpage.js
+++ b/client/finds_client/src/components/SearchResultpage.js
@@ -7,7 +7,8 @@ import GridListTileBar from '@material-ui/core/GridListTileBar';
 import ListSubheader from '@material-ui/core/ListSubheader';
 import IconButton from '@material-ui/core/IconButton';
 import InfoIcon from '@material-ui/icons/Info';
-
+import {push} from "connected-react-router";
+import {useDispatch} from "react-redux";
 
 const styles = theme => ({
   root: {
@@ -34,22 +35,13 @@ const tileData = [
     cols: 2,
     featured: true,
   },
-  {
-    img: 'https://i.imagesup.co/images2/0__05c7e8a33418ff.jpg',
-    title: 'dog',
-    author: 'Image by Free-Photos on Pixabay',
-  },
+
   {
     img: 'https://cdn.pixabay.com/photo/2014/12/27/15/31/camera-581126_1280.jpg',
     title: 'Camera',
     author: 'Image by Free-Photos on Pixabay',
   },
-  {
-    img: 'https://cdn.pixabay.com/photo/2017/05/12/08/29/coffee-2306471_1280.jpg',
-    title: 'Morning',
-    author: 'Image by Free-Photos on Pixabay',
-    featured: true,
-  },
+
   {
     img: 'https://cdn.pixabay.com/photo/2017/05/13/12/40/fashion-2309519__480.jpg',
     title: 'Hats',
@@ -82,20 +74,23 @@ const tileData = [
  */
  function SearchResultPage(props) {
    const classes = props;
-
+ const dispatch = useDispatch();
+  const moveToDocumentDetail = () => {
+  return (dispatch(push("/detail")));
+  }
   return (
     <div className={classes.root}>
       <GridList cellHeight={180} className={classes.gridList}>
-        <GridListTile key="Subheader" cols={4} style={{ height: 'auto' }}>
+        <GridListTile key="Subheader" cols={4} style={{ height: 'auto' }} >
         </GridListTile>
         {tileData.map(tile => (
           <GridListTile key={tile.img}>
-            <img src={tile.img} alt={tile.title} />
+            <img src={tile.img} alt={tile.title} onClick={moveToDocumentDetail}/>
             <GridListTileBar
               title={tile.title}
               subtitle={<span>作成者: {tile.author}</span>}
               actionIcon={
-                <IconButton aria-label={`info about ${tile.title}`} className={classes.icon}>
+                <IconButton aria-label={`info about ${tile.title}`} className={classes.icon}onClick={moveToDocumentDetail}>
                   <InfoIcon />
                 </IconButton>
               }

--- a/client/finds_client/src/components/TopAppBar.js
+++ b/client/finds_client/src/components/TopAppBar.js
@@ -67,15 +67,19 @@ function TopAppBar(props) {
   const moveToHome = () => {
     return (dispatch(push("/Home")));
   }
+  const moveToResult = () => {
+    return (dispatch(push("/result")));
+  }
+
     return (
         <div className={classes.root}>
             <AppBar position="static">
                 <Toolbar>
           <div className={classes.search}>
             <div className={classes.searchIcon}>
-                <SearchIcon/>
+               <SearchIcon onClick={moveToResult}/>
             </div>
-            <InputBase
+              <InputBase
               placeholder="新しい勉強資料を探す"
               fullWidth="100%"
               classes={{
@@ -83,6 +87,7 @@ function TopAppBar(props) {
                 input: classes.inputInput,
               }}
                 inputProps={{ 'aria-label': 'search' }}
+                onClick={moveToResult}
             />
             </div>
             <Typography variant="title" color="inherit" className={classes.flex}>

--- a/client/finds_client/src/reducers/finds.js
+++ b/client/finds_client/src/reducers/finds.js
@@ -1,0 +1,17 @@
+import *as actionTypes from '../actions/actionTypes';
+
+
+const initialState = {
+  hoge:0,
+};
+
+export function finds(state = initialState, action) {
+    switch (action.type) {
+        case 'LOGIN':
+        case 'HOME':
+        default:
+            return state;
+    }
+}
+
+export default finds;


### PR DESCRIPTION
## 関連Issue
close #31 

## やったこと
SearchResultPage画面の実装
SearchResultPage画面からDocumentDetailPage画面への遷移機能の実装
## 実装の詳細

> どのように実装したかを書きます（なるべく詳しく書いた方が良い）
SearchResultPage.jsを追加した
GridListTileタグとGridListTileBarタグ内にonClick={moveToDocumentDetail}を追加した
## スクリーンショット(あれば)
<img width="959" alt="無題" src="https://user-images.githubusercontent.com/38876698/69492755-ad8ba380-0ee9-11ea-9dcb-92842a626e6c.png">

