### PR TITLE
ログイン画面をレスポンシブに修正

### DIFF
--- a/client/finds_client/src/components/login.js
+++ b/client/finds_client/src/components/login.js
@@ -1,4 +1,4 @@
-import React,{useState} from 'react';
+import React, { useState } from 'react';
 import { withRouter } from 'react-router';
 import '../styles/login.css';
 import {
@@ -8,9 +8,9 @@ import {
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
 import { deepPurple } from '@material-ui/core/colors';
-import {push} from "connected-react-router";
-import {useDispatch} from "react-redux";
-import {getLoginRequest} from "../actions/actionTypes"
+import { push } from "connected-react-router";
+import { useDispatch } from "react-redux";
+import { getLoginRequest } from "../actions/actionTypes"
 
 const darkViolet = deepPurple['A700'];
 
@@ -38,11 +38,17 @@ const CssTextField = withStyles({
 
 const useStyles = makeStyles(theme => ({
     margin: {
-        marginTop: theme.spacing(2),
+        marginTop: theme.spacing(3),
+        width: '50vw',
     },
     margin5: {
         marginTop: theme.spacing(5),
+        width: '50vw',
     },
+    marginButton: {
+        marginTop: theme.spacing(5),
+        width: '30vw',
+    }
 }));
 
 const ColorButton = withStyles(theme => ({
@@ -58,14 +64,14 @@ const ColorButton = withStyles(theme => ({
 const Login = props => {
     const classes = useStyles();
     const dispatch = useDispatch();
-    const [id,setId]=useState("");
-    const [password,setPassword]=useState("");
+    const [id, setId] = useState("");
+    const [password, setPassword] = useState("");
     const moveToMyDocumentList = () => {
-        const info={id,password}
+        const info = { id, password }
         dispatch(getLoginRequest(info))
     }
     return (
-        <div className="inner">
+        <div className="loginInner">
             <h1>finds</h1>
             <CssTextField
                 className={classes.margin5}
@@ -73,7 +79,7 @@ const Login = props => {
                 variant="outlined"
                 id="custom-css-outlined-input"
                 fullWidth
-                onChange={(e)=>setId(e.target.value)}
+                onChange={(e) => setId(e.target.value)}
                 InputLabelProps={{
                     style: {
                     }
@@ -89,7 +95,7 @@ const Login = props => {
                 variant="outlined"
                 id="custom-css-outlined-input"
                 fullWidth
-                onChange={(e)=>setPassword(e.target.value)}
+                onChange={(e) => setPassword(e.target.value)}
                 inputProps={{
                     style: {
                     },
@@ -98,7 +104,7 @@ const Login = props => {
             <ColorButton
                 variant="contained"
                 color="primary"
-                className={classes.margin5}
+                className={classes.marginButton}
                 onClick={moveToMyDocumentList}
             >
                 LOGIN

--- a/client/finds_client/src/styles/login.css
+++ b/client/finds_client/src/styles/login.css
@@ -1,10 +1,11 @@
-.inner {
-  text-align: center;
-  width: 20%;
-  margin: 5% auto;
+.loginInner {
+  display: flex;
+  margin: 10% auto 0 auto;
+  flex-direction: column;
+  align-items: center;
 }
 
 .buttonUnderText {
   display: inline-block;
-  margin-top: 10%;
+  margin-top: 5%;
 }

--- a/client/finds_client/src/styles/myPage.css
+++ b/client/finds_client/src/styles/myPage.css
@@ -1,6 +1,7 @@
 .inner {
   width: 70%;
   margin: 10% auto;
+  text-align: center;
 }
 
 .box {


### PR DESCRIPTION
## 関連Issue

> close #49 
## やったこと

> やったことを書きます
> ログイン画面をレスポンシブに修正

## 実装の詳細

> どのように実装したかを書きます（なるべく詳しく書いた方が良い）
> 例: LoginActivityを作成し、起動時に表示されるようにしました。

## レビューして欲しいところ

> 実装が不安なところなど、レビューして欲しいことを書きます

## スクリーンショット(あれば)

> UIに変更を加えた祭はスクショがあるとわかりやすいです。変更前・変更後のスクショがあると良い

PC
<img width="1278" alt="スクリーンショット 2019-12-13 23 12 45" src="https://user-images.githubusercontent.com/44424051/70806213-22257400-1dfe-11ea-85f4-18721cd5dd7b.png">

スマホ
<img width="207" alt="スクリーンショット 2019-12-13 23 12 59" src="https://user-images.githubusercontent.com/44424051/70806235-2d789f80-1dfe-11ea-8a6a-cb1f9aa45b42.png">