### PR TITLE
Feat/upload page

### DIFF
--- a/client/finds_client/public/index.html
+++ b/client/finds_client/public/index.html
@@ -24,8 +24,8 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <style>
-      body{
-        margin:0;
+      body {
+        margin: 0;
       }
     </style>
     <title>React App</title>

--- a/client/finds_client/src/App.js
+++ b/client/finds_client/src/App.js
@@ -8,23 +8,24 @@ import Home from "./components/home";
 import Error from "./components/Error";
 import DocumentDetailPage from "./components/DocumentDetailPage";
 import MyPage from "./components/myPage";
+import UploadPage from "./components/UploadPage";
 import TopAppBar from './components/TopAppBar';
 
 function App() {
   var url = window.location.href;
   return (
     <div>
-
-    <ConnectedRouter history={history}>
-      <Switch>
-        <Route exact path="/login" component={Login} />
-        <Route exact path="/home" component={Home} />
-        <Route path="/detail" component={DocumentDetailPage} />
-        <Route exact path="/result" component={Result}/>
-        <Route exact path="/myPage" component={MyPage} />
-        <Route path="/" component={Login} />
-      </Switch>
-    </ConnectedRouter>
+      <ConnectedRouter history={history}>
+        <Switch>
+          <Route exact path="/login" component={Login} />
+          <Route exact path="/home" component={Home} />
+          <Route path="/detail" component={DocumentDetailPage} />
+          <Route exact path="/result" component={Result} />
+          <Route exact path="/myPage" component={MyPage} />
+          <Route exact path="/UploadPage" component={UploadPage} />
+          <Route path="/" component={Login} />
+        </Switch>
+      </ConnectedRouter>
     </div>
   );
 }

--- a/client/finds_client/src/apis/Search.js
+++ b/client/finds_client/src/apis/Search.js
@@ -1,11 +1,11 @@
 import * as request from "superagent";
 
 export const getSearchResult = (docName) => {
-    return request.get(`https://private-anon-14c3863ce4-finds1.apiary-mock.com/search/${docName}`)
+    return request.get(`https://private-anon-09b303e34c-finds1.apiary-mock.com/search/${docName}`)
         .then(res => {
-            return {res:res.body};
+            return { res: res.body };
         }).catch(err => {
             console.log(err);
-            return {err};
+            return { err };
         })
 }

--- a/client/finds_client/src/apis/UserDoc.js
+++ b/client/finds_client/src/apis/UserDoc.js
@@ -1,11 +1,11 @@
 import * as request from "superagent";
 
 export const getUserDocument = (id) => {
-    return request.get(`https://private-anon-14c3863ce4-finds1.apiary-mock.com/documents/${id}`)
+    return request.get(`https://private-anon-09b303e34c-finds1.apiary-mock.com/search/${id}`)
         .then(res => {
-            return {res:res.body};
+            return { res: res.body };
         }).catch(err => {
             console.log(err);
-            return {err};
+            return { err };
         })
 }

--- a/client/finds_client/src/apis/UserInfo.js
+++ b/client/finds_client/src/apis/UserInfo.js
@@ -1,12 +1,12 @@
 import * as request from "superagent";
 
 export const getUserInfo = (userId) => {
-    return request.get(`http://private-anon-14c3863ce4-finds1.apiary-mock.com/userinfo/${userId}`)
+    return request.get(`https://private-anon-09b303e34c-finds1.apiary-mock.com/search/${userId}`)
         .then(res => {
             console.log(res)
             return { res: res.body };
         }).catch(err => {
             console.log(err);
-            return {err};
+            return { err };
         })
 }

--- a/client/finds_client/src/components/UploadPage.js
+++ b/client/finds_client/src/components/UploadPage.js
@@ -81,6 +81,7 @@ const UploadPage = props => {
                 <div className="upload_button_inner">
                     <ColorButton
                         variant="contained"
+                        onClick={moveToHome}
                     >
                         投稿する
                     </ColorButton>

--- a/client/finds_client/src/components/UploadPage.js
+++ b/client/finds_client/src/components/UploadPage.js
@@ -5,6 +5,8 @@ import {
     makeStyles,
     withStyles
 } from '@material-ui/core/styles';
+import { push } from "connected-react-router";
+import { useDispatch, useSelector } from "react-redux";
 import Button from '@material-ui/core/Button';
 import { IconButton } from '@material-ui/core';
 import Publish from '@material-ui/icons/Publish';
@@ -43,6 +45,10 @@ const ColorButton = withStyles(theme => ({
 
 const UploadPage = props => {
     const classes = useStyles();
+    const dispatch = useDispatch();
+    const moveToHome = () => {
+        return (dispatch(push("/home")));
+    }
     return (
         <div className="upload_reset">
             <div className="upload_margin"></div>
@@ -79,6 +85,7 @@ const UploadPage = props => {
                 <ColorButton
                     variant="contained"
                     className={classes.upload_button_bottom}
+                    onClick={moveToHome}
                 >
                     キャンセル
                 </ColorButton>

--- a/client/finds_client/src/components/UploadPage.js
+++ b/client/finds_client/src/components/UploadPage.js
@@ -1,12 +1,89 @@
 import React, { useState } from 'react';
 import { withRouter } from 'react-router';
-import '../styles/login.css';
+import Box from '@material-ui/core/Box';
+import {
+    makeStyles,
+    withStyles
+} from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import { IconButton } from '@material-ui/core';
+import Publish from '@material-ui/icons/Publish';
+import Input from '@material-ui/core/Input';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import { deepPurple } from '@material-ui/core/colors';
+import '../styles/uploadPage.css';
+const darkViolet = deepPurple['A700'];
+
+const useStyles = makeStyles(theme => ({
+    upload_icon_margin: {
+        display: "block",
+        margin: "0 auto"
+    },
+    upload_icon: {
+        color: "black",
+        fontSize: "35px",
+    },
+    upload_input: {
+        marginTop: "10px"
+    },
+    upload_button_bottom: {
+        marginTop: "10%"
+    }
+}));
+
+const ColorButton = withStyles(theme => ({
+    root: {
+        color: theme.palette.getContrastText(darkViolet),
+        backgroundColor: darkViolet,
+        '&:hover': {
+            backgroundColor: darkViolet,
+        },
+    },
+}))(Button);
 
 const UploadPage = props => {
+    const classes = useStyles();
     return (
-        <div>
-            <h1>UploadPageだよ！！！</h1>
-        </div>
+        <div className="upload_reset">
+            <div className="upload_margin"></div>
+            <Box borderRadius="10%" className="upload_box">
+                <div className="upload_inner">
+                    <IconButton className={classes.upload_icon_margin}>
+                        <Publish className={classes.upload_icon} />
+                    </IconButton>
+                    <p className="upload_icon_bottom">ノートをアップロードする</p>
+                </div>
+            </Box>
+            <p className="white_text">ノートとタイトルと説明</p>
+            <Box className="sentence_box">
+                <p className="grey_text">ノートタイトル（必須、40文字まで）</p>
+                <Input fullWidth placeholder="ノートタイトル" inputProps={{ 'aria-label': 'description' }} className={classes.upload_input} />
+                <p className="grey_text">説明（任意、1000文字まで）</p>
+                <Input fullWidth placeholder="分野、工夫した点、特徴、注意点など" inputProps={{ 'aria-label': 'description' }} className={classes.upload_input} />
+            </Box>
+            <p className="white_text">価格</p>
+            <Box className="sentence_box">
+                <Input
+                    type="number"
+                    fullWidth
+                    endAdornment={<InputAdornment position="end">FUNney</InputAdornment>}
+                    className="input_number"
+                />
+            </Box>
+            <div className="upload_button_inner">
+                <ColorButton
+                    variant="contained"
+                >
+                    投稿する
+                </ColorButton>
+                <ColorButton
+                    variant="contained"
+                    className={classes.upload_button_bottom}
+                >
+                    キャンセル
+                </ColorButton>
+            </div>
+        </div >
     )
 }
 export default withRouter(UploadPage)

--- a/client/finds_client/src/components/UploadPage.js
+++ b/client/finds_client/src/components/UploadPage.js
@@ -1,0 +1,12 @@
+import React, { useState } from 'react';
+import { withRouter } from 'react-router';
+import '../styles/login.css';
+
+const UploadPage = props => {
+    return (
+        <div>
+            <h1>UploadPageだよ！！！</h1>
+        </div>
+    )
+}
+export default withRouter(UploadPage)

--- a/client/finds_client/src/components/UploadPage.js
+++ b/client/finds_client/src/components/UploadPage.js
@@ -11,6 +11,7 @@ import Button from '@material-ui/core/Button';
 import { IconButton } from '@material-ui/core';
 import Publish from '@material-ui/icons/Publish';
 import Input from '@material-ui/core/Input';
+import TextField from '@material-ui/core/TextField';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import { deepPurple } from '@material-ui/core/colors';
 import '../styles/uploadPage.css';
@@ -26,10 +27,10 @@ const useStyles = makeStyles(theme => ({
         fontSize: "35px",
     },
     upload_input: {
-        marginTop: "10px"
+        marginTop: "5px"
     },
     upload_button_bottom: {
-        marginTop: "10%"
+        marginTop: "5%"
     }
 }));
 
@@ -60,35 +61,37 @@ const UploadPage = props => {
                     <p className="upload_icon_bottom">ノートをアップロードする</p>
                 </div>
             </Box>
-            <p className="white_text">ノートとタイトルと説明</p>
-            <Box className="sentence_box">
-                <p className="grey_text">ノートタイトル（必須、40文字まで）</p>
-                <Input fullWidth placeholder="ノートタイトル" inputProps={{ 'aria-label': 'description' }} className={classes.upload_input} />
-                <p className="grey_text">説明（任意、1000文字まで）</p>
-                <Input fullWidth placeholder="分野、工夫した点、特徴、注意点など" inputProps={{ 'aria-label': 'description' }} className={classes.upload_input} />
-            </Box>
-            <p className="white_text">価格</p>
-            <Box className="sentence_box">
-                <Input
-                    type="number"
-                    fullWidth
-                    endAdornment={<InputAdornment position="end">FUNney</InputAdornment>}
-                    className="input_number"
-                />
-            </Box>
-            <div className="upload_button_inner">
-                <ColorButton
-                    variant="contained"
-                >
-                    投稿する
+            <div className="upload_input_inner">
+                <p className="white_text">ノートとタイトルと説明</p>
+                <Box className="sentence_box">
+                    <TextField label="ノートタイトル" helperText="（必須、40文字まで）" fullWidth inputProps={{ 'aria-label': 'description' }} className={classes.upload_input} />
+                    <TextField label="説明(分野、工夫した点、特徴、注意点など)" helperText="（任意、1000文字まで）" fullWidth inputProps={{ 'aria-label': 'description' }} className={classes.upload_input} />
+                </Box>
+                <p className="white_text">価格</p>
+                <Box className="sentence_box">
+                    <Input
+                        type="number"
+                        fullWidth
+                        endAdornment={<InputAdornment position="end">FUNney</InputAdornment>}
+                        className="input_number"
+                    />
+                </Box>
+            </div>
+            <div className="upload_button_space">
+                <div className="upload_button_inner">
+                    <ColorButton
+                        variant="contained"
+                    >
+                        投稿する
+                    </ColorButton>
+                    <ColorButton
+                        variant="contained"
+                        className={classes.upload_button_bottom}
+                        onClick={moveToHome}
+                    >
+                        キャンセル
                 </ColorButton>
-                <ColorButton
-                    variant="contained"
-                    className={classes.upload_button_bottom}
-                    onClick={moveToHome}
-                >
-                    キャンセル
-                </ColorButton>
+                </div>
             </div>
         </div >
     )

--- a/client/finds_client/src/components/home.js
+++ b/client/finds_client/src/components/home.js
@@ -1,13 +1,18 @@
 import React from 'react';
 import TopAppBar from './TopAppBar';
 import MyDocumentList from './MyDocumentsList';
-
+import Fab from '@material-ui/core/Fab';
+import AddIcon from '@material-ui/icons/Add';
+import '../styles/home.css';
 
 const Home = props => {
     return (
-        <div>
+        <div className="positionStandard">
             <TopAppBar />
-            <MyDocumentList/>
+            <MyDocumentList />
+            <Fab className="positionAbsolute" color="primary" aria-label="add">
+                <AddIcon />
+            </Fab>
         </div>
     )
 }

--- a/client/finds_client/src/components/home.js
+++ b/client/finds_client/src/components/home.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { push } from "connected-react-router";
+import { useDispatch, useSelector } from "react-redux";
 import TopAppBar from './TopAppBar';
 import MyDocumentList from './MyDocumentsList';
 import Fab from '@material-ui/core/Fab';
@@ -6,13 +8,19 @@ import AddIcon from '@material-ui/icons/Add';
 import '../styles/home.css';
 
 const Home = props => {
+    const dispatch = useDispatch();
+    const moveToUploadPage = () => {
+        return (dispatch(push("/uploadPage")));
+    }
     return (
-        <div className="positionStandard">
+        <div>
             <TopAppBar />
             <MyDocumentList />
-            <Fab className="positionAbsolute" color="primary" aria-label="add">
-                <AddIcon />
-            </Fab>
+            <div className="positionFixed">
+                <Fab color="primary" aria-label="add" className="positionFixed" onClick={moveToUploadPage}>
+                    <AddIcon />
+                </Fab>
+            </div>
         </div>
     )
 }

--- a/client/finds_client/src/components/myPage.js
+++ b/client/finds_client/src/components/myPage.js
@@ -1,4 +1,4 @@
-import React ,{useEffect}from 'react';
+import React, { useEffect } from 'react';
 import { withRouter } from 'react-router';
 import '../styles/myPage.css';
 import {
@@ -10,7 +10,7 @@ import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import { deepPurple } from '@material-ui/core/colors';
 import { push } from "connected-react-router";
-import { useDispatch ,useSelector} from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import TopAppBar from './TopAppBar';
 import { getUserInfoRequest } from "../actions/actionTypes";
 const darkViolet = deepPurple['A700'];
@@ -45,9 +45,9 @@ const Mypage = props => {
     const classes = useStyles();
     const dispatch = useDispatch();
     const { userInfo } = useSelector(state => state.userInfo);
-    useEffect(()=>{
-     dispatch(getUserInfoRequest("b1018000"))
-   },[])
+    useEffect(() => {
+        dispatch(getUserInfoRequest("b1018000"))
+    }, [])
     const moveToLogin = () => {
         return (dispatch(push("/login")));
     }
@@ -58,9 +58,9 @@ const Mypage = props => {
             </div>
             <div className="inner">
                 <ColorBox color="text.primary" borderRadius="10%" className="box">
-                    <img src={userInfo.userIcon||"https://www.stickpng.com/assets/images/585e4bf3cb11b227491c339a.png"} class="material-icons" alt="sdfreghtrjy"></img><br></br>
+                    <img src={userInfo.userIcon || "https://www.stickpng.com/assets/images/585e4bf3cb11b227491c339a.png"} class="material-icons" alt="sdfreghtrjy"></img><br></br>
                     <Typography className="text_inner">
-      　　　　　　　　　　<span className="studentNumber">{userInfo.userId}</span>
+                        <span className="studentNumber">{userInfo.userId}</span>
                         <span className="funneyRest">のこり</span>
                         <span className="funneyNumber">{userInfo.balance}</span>
                         <span className="funneyUnit">FUNney</span>

--- a/client/finds_client/src/styles/home.css
+++ b/client/finds_client/src/styles/home.css
@@ -1,15 +1,5 @@
-/* .positionStandard {
-  position: relative;
-} */
-
-/* .positionStandard .positionAbsolute {
-  position: absolute;
-  bottom: 3%;
-  right: 3%;
-} */
-
-.positionAbsolute {
+.positionFixed {
   position: fixed;
-  right: 0px;
-  bottom: 0px;
+  right: 10px;
+  bottom: 10px;
 }

--- a/client/finds_client/src/styles/home.css
+++ b/client/finds_client/src/styles/home.css
@@ -1,0 +1,15 @@
+/* .positionStandard {
+  position: relative;
+} */
+
+/* .positionStandard .positionAbsolute {
+  position: absolute;
+  bottom: 3%;
+  right: 3%;
+} */
+
+.positionAbsolute {
+  position: fixed;
+  right: 0px;
+  bottom: 0px;
+}

--- a/client/finds_client/src/styles/myPage.css
+++ b/client/finds_client/src/styles/myPage.css
@@ -1,6 +1,6 @@
 .inner {
-  width: 40%;
-  margin: 5% auto;
+  width: 50%;
+  margin: 10% auto 0 auto;
   text-align: center;
 }
 
@@ -9,9 +9,9 @@
   padding-bottom: 10%;
 }
 
-.material-icons{
-width: 60px;
-height:60px;
+.material-icons {
+  width: 60px;
+  height: 60px;
 }
 
 .text_inner {

--- a/client/finds_client/src/styles/uploadPage.css
+++ b/client/finds_client/src/styles/uploadPage.css
@@ -1,0 +1,58 @@
+.upload_reset {
+  background-color: #a9a9a9;
+  height: 100vh;
+  overflow: visible;
+}
+
+.upload_margin {
+  height: 5vh;
+  background-color: #a9a9a9;
+}
+
+.upload_box {
+  display: flex;
+  flex-direction: column;
+  height: 30%;
+  margin: 0 25%;
+  background-color: white;
+}
+
+.upload_inner {
+  margin: auto;
+}
+
+.upload_icon_bottom {
+  display: block;
+  font-size: 13px;
+  color: black;
+  margin: 0 auto;
+}
+
+.white_text {
+  display: block;
+  color: white;
+  margin-top: 30px;
+  margin-bottom: 0;
+}
+
+.grey_text {
+  display: block;
+  color: #a9a9a9;
+  margin: 0;
+  padding-top: 15px;
+}
+
+.sentence_box {
+  background-color: white;
+  padding: 0px 10px 10px 10px;
+}
+
+.input_number {
+  padding-top: 10px;
+}
+
+.upload_button_inner {
+  margin: 10% 15%;
+  display: flex;
+  flex-direction: column;
+}

--- a/client/finds_client/src/styles/uploadPage.css
+++ b/client/finds_client/src/styles/uploadPage.css
@@ -1,18 +1,17 @@
 .upload_reset {
   background-color: #a9a9a9;
   height: 100vh;
-  overflow: visible;
 }
 
 .upload_margin {
-  height: 5vh;
+  height: 3vh;
   background-color: #a9a9a9;
 }
 
 .upload_box {
   display: flex;
   flex-direction: column;
-  height: 30%;
+  height: 30vh;
   margin: 0 25%;
   background-color: white;
 }
@@ -28,18 +27,15 @@
   margin: 0 auto;
 }
 
+.upload_input_inner {
+  height: 30vh;
+}
+
 .white_text {
   display: block;
   color: white;
-  margin-top: 30px;
+  margin-top: 1vh;
   margin-bottom: 0;
-}
-
-.grey_text {
-  display: block;
-  color: #a9a9a9;
-  margin: 0;
-  padding-top: 15px;
 }
 
 .sentence_box {
@@ -51,8 +47,13 @@
   padding-top: 10px;
 }
 
+.upload_button_space {
+  margin-top: 15vh;
+  height: 20vh;
+}
+
 .upload_button_inner {
-  margin: 10% 15%;
+  margin: 0% 15%;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
## 関連Issue

> このPRと関連するIssueの番号を書きます
> アップロード画面
> close #24 

## やったこと

> やったことを書きます
> アップロード画面の実装、遷移（ホームからアップロード、アップロードからホーム）、ホーム画面にアップロード画面に遷移するボタン実装

## 実装の詳細

> どのように実装したかを書きます（なるべく詳しく書いた方が良い）
> アップロード画面の実装（iphone5s以外はレイアウトが崩れないようにできました。）
> 遷移（値の受け渡しは一つもしないでただ遷移してるだけ）
> ホーム画面にボタン実装（右下に固定したボタンを作成）

## レビューして欲しいところ

> コード汚いですけど、写真で判断してください。

## スクリーンショット(あれば)

> UIに変更を加えた祭はスクショがあるとわかりやすいです。変更前・変更後のスクショがあると良い
> iPhone X
<img width="190" alt="iPhoneX" src="https://user-images.githubusercontent.com/44424051/72481127-de7abb80-383c-11ea-9035-c36f25c0f158.png">

> iPhone 6/7/8
<img width="227" alt="iPhone6:7:8" src="https://user-images.githubusercontent.com/44424051/72481135-e3d80600-383c-11ea-9d37-52d936f90610.png">

> Pixel 2
<img width="227" alt="Pixel2" src="https://user-images.githubusercontent.com/44424051/72481144-ec304100-383c-11ea-8d9e-2bf3932be8bc.png">

> PC
<img width="1280" alt="PC" src="https://user-images.githubusercontent.com/44424051/72481153-efc3c800-383c-11ea-9a4a-4dc89cd24f21.png">

> ホーム画面に実装したボタン
<img width="185" alt="finds_home" src="https://user-images.githubusercontent.com/44424051/72481206-1da90c80-383d-11ea-8372-17748bdd2a37.png">